### PR TITLE
Add COLABS site

### DIFF
--- a/SeedProjects.md
+++ b/SeedProjects.md
@@ -2,7 +2,7 @@
 
 On Monday, April 3, 2023, the US Department of Energy Office of Advanced Scientific Computing Research (ASCR) announced the selection of six "seed" projects to collaboratively plan for software-ecosystem sustainment as the US Exascale Computing Project ends.  This page provides a link to each project's main page.
 
-- [COLABS: Collaboration of Oak Ridge National Lab, LBNL, and ANL for Better Software - TBA]()
+- COLABS: Collaboration for Better Software (for Science) - <https://colabs-science.github.io/>
 - [SWAS: Center for Sustaining Workflows and Application Services](https://swas.center/)
 - [PESO: Toward a Post-ECP Software-Sustainability Organization](PESO.md)
 - [STEP: Sustainable Tools Ecosystem Project - TBA]()


### PR DESCRIPTION
I prefer to expose the URL so that people can see and remember it.

Also, we've adjusted the expansion of our COLABS acronym to be more succinct.